### PR TITLE
Implement Anonymous User Name Feature

### DIFF
--- a/templates/partials/post_bar.tpl
+++ b/templates/partials/post_bar.tpl
@@ -7,6 +7,12 @@
 					<i class="fa fa-fw fa-inbox text-primary"></i>
 					<span class="d-none d-md-inline fw-semibold">[[topic:mark-unread]]</span>
 				</button>
+
+				<button id="toggleResolveBtn" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center" onclick="toggleResolve()">
+					<i id="resolveIcon" class="fa fa-fw fa-check text-primary"></i>
+					<span id="toggleResolveText" class="d-none d-md-inline fw-semibold">Mark Resolved</span>
+				</button>
+
 				{{{ end }}}
 
 				<!-- IMPORT partials/topic/watch.tpl -->

--- a/templates/partials/post_bar.tpl
+++ b/templates/partials/post_bar.tpl
@@ -8,11 +8,11 @@
 					<span class="d-none d-md-inline fw-semibold">[[topic:mark-unread]]</span>
 				</button>
 
-				<button id="toggleResolveBtn" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center" onclick="toggleResolve()">
-					<i id="resolveIcon" class="fa fa-fw fa-check text-primary"></i>
-					<span id="toggleResolveText" class="d-none d-md-inline fw-semibold">Mark Resolved</span>
-				</button>
 
+				<button component="topic/mark-resolved" id="mark-resolve-btn" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
+					<i id="resolve-icon" class="fa fa-fw fa-check text-primary"></i>
+					<span id="resolve-text" class="d-none d-md-inline fw-semibold">Mark Resolved</span>
+				</button>
 				{{{ end }}}
 
 				<!-- IMPORT partials/topic/watch.tpl -->

--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -11,23 +11,20 @@
 
 <div class="d-flex align-items-start gap-3">
 	<!-- Check if posts.anonymous is truthy (e.g., "true") -->
-	{{{ if !posts.anonymous }}}
-
+	{{{ if posts.anonymous }}}
+		<!-- Anonymous User Block -->
 		<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
-			<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
+			<a class="d-inline-block position-relative text-decoration-none" href="#" aria-label="[[aria:user-avatar-for, "Anonymous"]]">
 				<!-- Display Avatar for Anonymous -->
-				{buildAvatar(posts.user, "48px", true, "", "user/picture")}
-				<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}">
-					<span class="visually-hidden">[[global:{posts.user.status}]]</span>
-				</span>
+				<img src="{config.relative_path}/assets/images/anonymous-avatar.png" alt="Anonymous">
 			</a>
 		</div>
 	{{{ else }}}
-		<!-- Display when posts.anonymous is (e.g., "true" or not defined) -->
-
+		<!-- Non-Anonymous User Block -->
 		<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
-			<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, "Anonymous"]]">
-				<!-- Display Avatar for Non-Anonymous -->
+			<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
+				<!-- Display User Avatar -->
+				{buildAvatar(posts.user, "48px", true, "", "user/picture")}
 			</a>
 		</div>
 	{{{ end }}}

--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -11,7 +11,7 @@
 
 <div class="d-flex align-items-start gap-3">
 	<!-- Check if posts.anonymous is truthy (e.g., "true") -->
-	{{{ if posts.anonymous }}}
+	{{{ if !posts.anonymous }}}
 		<!-- Anonymous User Block -->
 		<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
 			<a class="d-inline-block position-relative text-decoration-none" href="#" aria-label="[[aria:user-avatar-for, "Anonymous"]]">
@@ -44,12 +44,12 @@
 					</a>
 				</div>
 
-				<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+				<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">Anonymous</a>
 
 			{{{ else }}}
 				
 
-				<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">Anonymous</a>
+				<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
 			{{{end}}}
 
 			{{{ each posts.user.selectedGroups }}}

--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -5,26 +5,55 @@
 	{{{ end }}}
 </div>
 {{{ end }}}
+
+
+
+
 <div class="d-flex align-items-start gap-3">
-	<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
-		<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
-			{buildAvatar(posts.user, "48px", true, "", "user/picture")}
-			<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
-		</a>
-	</div>
+	<!-- Check if posts.anonymous is truthy (e.g., "true") -->
+	{{{ if !posts.anonymous }}}
+
+		<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
+			<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
+				<!-- Display Avatar for Anonymous -->
+				{buildAvatar(posts.user, "48px", true, "", "user/picture")}
+				<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}">
+					<span class="visually-hidden">[[global:{posts.user.status}]]</span>
+				</span>
+			</a>
+		</div>
+	{{{ else }}}
+		<!-- Display when posts.anonymous is (e.g., "true" or not defined) -->
+
+		<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
+			<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, "Anonymous"]]">
+				<!-- Display Avatar for Non-Anonymous -->
+			</a>
+		</div>
+	{{{ end }}}
+
+
 	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">
 		<div class="d-flex align-items-center gap-1 flex-wrap w-100 post-header mt-1" itemprop="author" itemscope itemtype="https://schema.org/Person">
 			<meta itemprop="name" content="{./user.username}">
 			{{{ if ./user.userslug }}}<meta itemprop="url" content="{config.relative_path}/user/{./user.userslug}">{{{ end }}}
 
-			<div class="bg-body d-sm-none">
-				<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
-					{buildAvatar(posts.user, "20px", true, "", "user/picture")}
-					<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
-				</a>
-			</div>
+			{{{ if !posts.anonymous }}}
 
-			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+				<div class="bg-body d-sm-none">
+					<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
+						{buildAvatar(posts.user, "20px", true, "", "user/picture")}
+						<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
+					</a>
+				</div>
+
+				<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+
+			{{{ else }}}
+				
+
+				<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">Anonymous</a>
+			{{{end}}}
 
 			{{{ each posts.user.selectedGroups }}}
 			{{{ if posts.user.selectedGroups.slug }}}


### PR DESCRIPTION
**Description:**
I implemented a new feature to show annoymous as their user name when they click "Post Annouymouly".

**Changes Made:**
1. Modified Conditional Rendering for Anonymous Posts: Replaced {{{ if !posts.anonymous }}} with {{{ if posts.anonymous }}} to ensure the block only renders when posts.anonymous is set to true.
2. Anonymous User Block: Changed the a tag that displays the user’s profile link to show the label Anonymous and used an anonymous avatar (anonymous-avatar.png) for these posts.
3. Updated Non-Anonymous User Block: Ensured the non-anonymous block only renders when posts.anonymous is false or undefined.
<img width="426" alt="Screenshot 2024-09-29 at 12 37 17 PM" src="https://github.com/user-attachments/assets/e3c41c1d-cbfd-4ffb-b1d7-c05c29d693da">
<img width="814" alt="Screenshot 2024-09-29 at 12 36 41 PM" src="https://github.com/user-attachments/assets/5d104a79-11ce-4449-950a-d46b06419c3c">

After refresh:
<img width="807" alt="Screenshot 2024-09-29 at 12 37 26 PM" src="https://github.com/user-attachments/assets/f4505dae-65f1-490e-8c0f-a0faa4bc8e85">


**Issue:**
- The post.tpl file always shows posts.anonymous as false, regardless of the value set by the frontend. After refreshing the page, all posts revert to being non-anonymous.
- It seems that the backend is overriding the anonymous flag, causing it to reset to false when reloading the page.

**How to Test:**
- Navigate to any discussion thread.
- You should see a "Reply Anonymously" button next to the standard Quick Reply button.
- Clicking on "Reply Anonymously" should allow you to post a reply anonymously. However, the anonymity will not persist due to the aforementioned issue.

**Next Steps:**
- Investigate why the anonymous flag is being reset to false in the backend.
- Ensure that the anonymous status persists when page refreshes.